### PR TITLE
Remove "Cloud Native 12 Factor App Principles" topic from Core SE archetype

### DIFF
--- a/src/archetypes/core-software-engineer-archetype.md
+++ b/src/archetypes/core-software-engineer-archetype.md
@@ -60,7 +60,6 @@ This archetype forms the basis for many others and is often the first step in sh
 * REST design
 * General API Design and Security Principles
 * Domain Driven Design
-* Cloud Native 12 Factor App Principles
 * Performance and Scalability
 * Component Architectures
 * Shifting Left Security


### PR DESCRIPTION
This pull request aims to resolve #12 by:

### Source File Updates:

* [`src/archetypes/core-software-engineer-archetype.md`](diffhunk://#diff-ff680b4481ba5ef054fd961b423eece6eccb92bc015c3d1539ec97835a28dc3bL63): Removed "Cloud Native 12 Factor App Principles" from the competency list in the Core Software Engineer Archetype.