### PR TITLE
Remove "Economics & FinOps" topic from Core Software Engineer Archetype

### DIFF
--- a/src/archetypes/core-software-engineer-archetype.md
+++ b/src/archetypes/core-software-engineer-archetype.md
@@ -91,5 +91,4 @@ This archetype forms the basis for many others and is often the first step in sh
 * Ethical and Responsible Tech
 * GDPR and other governance requirements
 * Knowledge of intellectual property laws, data privacy and ethical hacking practices
-* Economics & FinOps
 * Emerging Technologies & Tech Trends


### PR DESCRIPTION
This pull request aims to resolve #17 by:

### Archetype Definition Updates:

* Removed "Economics & FinOps" from the markdown file for the Core Software Engineer Archetype in `src/archetypes/core-software-engineer-archetype.md`.