### PR TITLE
content: rename legal & ethical topic in Core SE Archetype

### DIFF
--- a/src/archetypes/core-software-engineer-archetype.md
+++ b/src/archetypes/core-software-engineer-archetype.md
@@ -86,5 +86,5 @@ This archetype forms the basis for many others and is often the first step in sh
 * Site Reliability Engineering for Developers
 * Ethical and Responsible Tech
 * GDPR and other governance requirements
-* Knowledge of intellectual property laws, data privacy and ethical hacking practices
+* Legal & Ethical Awareness in Software Development
 * Emerging Technologies & Tech Trends


### PR DESCRIPTION
This pull request aims to resolve #19 and updates the `src/archetypes/core-software-engineer-archetype.md` file to refine the language and improve clarity in the list of core competencies for software engineers.

* Updated a competency description from "Knowledge of intellectual property laws, data privacy and ethical hacking practices" to "Legal & Ethical Awareness in Software Development" for better alignment and clarity.