### PR TITLE
Adding frontmatter for core software engineer archetype

### DIFF
--- a/src/archetypes/core-software-engineer-archetype.md
+++ b/src/archetypes/core-software-engineer-archetype.md
@@ -43,12 +43,12 @@ skill_stages:
       - clean-code-and-refactoring
       - integrated-component-tests
       - technical-architecture-intro
-      - data-modeling-adnd-databases
+      - data-modeling-and-databases
       - continuous-delivery
       - legacy-systems
       - root-cause-analysis
       - cloud-computing
-      - multiplelanguages-and-paradigms
+      - multiple-languages-and-paradigms
       - automated-end-to-end-system-testing
       - styleguides-and-linting
       - rest-design


### PR DESCRIPTION
Includes:
- Full YAML frontmatter for skill stages for Core Software Engineer Archetype
- All topic slugs preserved from original markdown
- Compatible with MkDocs macros for render_skill_stages()